### PR TITLE
small changes, better aside stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@
 - *Optimized Sub-optimal*
 
 
-
+ex.
+```
 > [!STICKY| blue title right s-80] 
 > > Comment #1 
 > > [[CSS stickynotes3.7]]
@@ -89,7 +90,7 @@ text text text
 
 <br><br>
 text ^there was one `<br>` tag for no overlap
-
+```
 
 > Sticky Notes for Obsidian
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,96 @@
 # obsidian-sticky-notes
 
+
+#### new and expanded features
+- Floating cue section
+	- `| float` metadata/parameter to make a sticky note float to the left side of your note. ex. `> [!sticky | blue float s-40]`
+	- this placement mirrors the cue section of the *Cornell note-taking system*.
+	- why not right side? we read from left to right, so the cue stickies will gain more attention.
+	- In editing mode, floating stickies will return to the normal margins but with a more transparent look, indicating that it is a floating/cue sticky. Note: don't space floating sticky notes closely in line numbers or else they would overlap. Why would you even need multiple cue stickies that close? you should have floating notes at s-30, you can make it larger, but it will overlap to the main notes section, if you still want it to be that large but not overlap, you can use `<br>` tags.
+- Zoom on hover - self-explanatory
+- Collapsible stickies 
+	- add a `+` or `-` sign after `[!sticky|metadata]` to make it collapsible with the default state of open and close correspondently. ex. `> [!sticky | yellow]-`
+	- clicking on the arrow`>` or header on top of the sticky note will expand/collapse it.
+- more sticky widths, up to 95%
+- standardized all markdown colors in sticky note.
+- slightly changed color system, should be natural for both dark and light mode
+- removed default titles and callout icons.
+
+- *Optimized Sub-optimal*
+
+
+
+> [!STICKY| blue title right s-80] 
+> > Comment #1 
+> > [[CSS stickynotes3.7]]
+> > As long as you listen in Dr. Neto's class, you don't need any extra classes after school
+
+test test test test 
+test test test test 
+test test test test 
+test test test test 
+test test test test 
+test test test test 
+
+
+
+
+
+
+
+
+
+
+> [!sticky | left yellow]+
+>  **Comment #1** 
+> As long as you listen in Dr. Neto's class, you don't need any extra classes after school
+> this is a collapsible note, defaulted as open.
+
+eeeee
+
+
+>[!sticky | float right blue s-30]
+>this is a floating/cue note
+>hello
+>hello
+>hello
+
+
+
+
+
+
+aa
+a
+a
+a
+a
+
+> [!sticky | ctr s-30]- title
+> hello
+> [[CSS stickynotes3.7]]
+a
+
+						^ this is a collapsible note, defaulted to closed
+>[!sticky | float left s-30]+
+>hello
+>hello
+>another one! collapsible too
+
+e
+text text text
+text text text
+text text text
+text text text
+text text text
+>[!sticky | float purple s-90]
+>loooooong
+>
+
+<br><br>
+text ^there was one `<br>` tag for no overlap
+
+
 > Sticky Notes for Obsidian
 
 <img src="https://github.com/dhniceday/obsidian-sticky-notes/blob/main/images/sticky-notes-readme1.png" alt="Sticky Notes in Obsidian" />

--- a/sticky-notes.css
+++ b/sticky-notes.css
@@ -1,292 +1,221 @@
 /* STICKY NOTES */
-/* Release v1.3 */
+/*v1.3  --dhniceday*/
+/*Release v1.7 caezium*/
 @charset "UTF-8";
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Mono&family=IBM+Plex+Sans&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Edu+SA+Beginner&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Architects+Daughter&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Kalam&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Chilanka&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Playpen+Sans&display=swap');
-@import url('https://fonts.googleapis.com/css2?family=Shantell+Sans&display=swap');
 
-
-:root {  
-  --sticky-color-green: #b8bb26cc;
-  --sticky-color-red: #fb4934cc;
-  --sticky-color-yellow: #FABD2Fcc;
-  --sticky-color-blue: #83a598cc;
-  --sticky-color-purple: #d3869bcc;
-  --sticky-color-aqua: #8ec07ccc;
-  --sticky-color-orange: #fe8019cc;
-  
-  --sticky-color-default: #FABD2Fcc;
-  --sticky-color-text: #282828;
-  --sticky-note-max-width: 600px;
-  --sticky-border-radius: 8px;
-}
-
-body {
-  --sticky-width: 30%;
-  --sticky-offset: 16px;
-  --line-width: var(--file-line-width, --line-width);
-}
-
-.callout.callout.callout[data-callout~=sticky]:is([data-callout-metadata~=left]):not([data-callout-metadata~=nofloat]) {
-  float: left;
-  margin: unset;
-  margin-right: 8px;
-}
-
-.callout.callout.callout[data-callout~=sticky]:is([data-callout-metadata~=nofloat]) {
-  float: unset !important;
-  margin-bottom: 20px !important;
-}
-
-.callout.callout[data-callout~=sticky]:is([data-callout-metadata~=right]) {
-  float: right;
-  margin: unset;
-  margin-left: 8px;
-}
-
-.callout.callout.callout[data-callout~=sticky]:is([data-callout-metadata~=ctr],
-[data-callout-metadata~=center]) {
-  display: block;
-  margin: auto;
-  float: unset;
+:root {
+        --sticky-color-green: #b8bb26cc;
+        --sticky-color-red: #fb4934cc;
+        --sticky-color-yellow: #FABD2Fcc;
+        --sticky-color-blue: #83a598cc;
+        --sticky-color-purple: #d3869bcc;
+        --sticky-color-aqua: #8ec07ccc;
+        --sticky-color-orange: #fe8019cc;
+        --sticky-color-pink: #f6a7c1;
+        --sticky-color-brown: #b16e4b;
+        --sticky-color-turquoise: #40E0D0;
+        --sticky-color-salmon: #ffbfa3;
+        --sticky-color-indigo: #ceace6;
+        --sticky-color-magenta: #f49ac2;
+        --sticky-color-violet: #cb99c9;
+        --sticky-color-green-transparent: #b8bb2682;
+        --sticky-color-red-transparent: #fb483481;
+        --sticky-color-yellow-transparent: #fabd2f7e;
+        --sticky-color-blue-transparent: #83a59882;
+        --sticky-color-purple-transparent: #d3869a86;
+        --sticky-color-aqua-transparent: #8ec07c79;
+        --sticky-color-orange-transparent: #fe801980;
+        --sticky-note-max-width: 600px;
+        --sticky-border-radius: 8px;
+        --sticky-font-size: 14px; /* adjust if needed*/
+        --sticky-font: sans-serif; /*adjust*/
+        --sticky-width: 30%;
+        --sticky-offset: 16px;
+        --line-width: var(--file-line-width, --line-width);
+        --sticky-color-text: black;
 }
 
 .callout[data-callout~=sticky] {
-  --callout-icon: sticky-note;
-  background-color: var(--sticky-color-default) !important;
-  color: var(--sticky-color-text);
-  font-family: var(--sticky-font);
-  font-size: var(--sticky-font-size);
-  max-width: var(--sticky-note-max-width); 
-  margin: auto;
-  display: block;
-  float: unset;
+        --callout-icon: none;
+        background-color: var(--sticky-color-yellow) !important;
+        color: var(--sticky-color-text);
+        font-family: var(--sticky-font);
+        font-size: var(--sticky-font-size);
+        max-width: var(--sticky-note-max-width);
+        margin: auto;
+        border-radius: var(--sticky-border-radius) !important;
+        border-width: 1px !important;
+        padding: 10px;
+        display: block;
+        float: unset;
+        transition: transform 0.3s ease, box-shadow 0.3s ease;
+        position: relative;
+        > .callout-content > :first-child {
+                margin-top: 0px;
+        }
+        > .callout-content > :last-child {
+                margin-bottom: 0px;
+        }
+        will-change: transform, box-shadow;
+        opacity: 1;
+}    
+.callout[data-callout~=sticky] .callout-icon{
+        display: none;
 }
 
-.callout[data-callout~=sticky]:is([data-callout-metadata~=s-35]) { --sticky-width: 35%; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=s-40]) { --sticky-width: 40%; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=s-45]) { --sticky-width: 45%; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=s-50]) { --sticky-width: 50%; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=s-55]) { --sticky-width: 55%; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=s-60]) { --sticky-width: 60%; }
-.callout[data-callout~=sticky] { width: var(--sticky-width); }
-
-.callout[data-callout~=sticky] .callout-title { display: none; }
-.callout[data-callout~=sticky] .callout-title-inner { padding-top: 0.25em; }
-.callout[data-callout~=sticky] .callout-content { padding: 10px; }
-
-.callout[data-callout~=sticky] {
-  border-radius: var(--sticky-border-radius) !important;
-  border-width: 1px !important;
-  padding: 0px;
-  > .callout-content > :first-child {
-      margin-top: 0px;
-  }
-  > .callout-content > :last-child {
-      margin-bottom: 0px;
-  }
+.callout[data-callout~=sticky]:hover,
+.callout[data-callout~=sticky]:focus {
+        box-shadow: 10px 10px 7px rgba(40, 40, 40, .7);
+        transform: scale(1.03); /*zoom scale HERE. zoom will also be in effect while in editing mode and will clip tho, but not a big problem.*/
+        z-index: 10;
+        opacity: 1;
 }
 
+
+
+.callout[data-callout~=sticky] .callout-title {
+        display: block;
+        color: var(--sticky-color-text);
+        margin: 0;
+}
+.callout[data-callout~=sticky] .callout-title-inner {
+        padding-top: 0.25em;
+        display: none;
+}
+
+.callout[data-callout~=sticky] blockquote {
+        color: var(--sticky-color-text);
+        border-left-color: var(--sticky-color-text);
+}
+
+.callout[data-callout~=sticky] .callout-content {
+        padding: 10px;
+}
 .callout[data-callout~=sticky] .callout-content strong,
 .callout[data-callout~=sticky] .callout-content em {
-  color: var(--sticky-color-text);
-  text-decoration: none;
+        color: var(--sticky-color-text);
+        text-decoration: none;
 }
-
 .callout[data-callout~=sticky] .callout-content a.internal-link,
-.callout[data-callout~=sticky] .callout-content a.external-link { 
-  color:var(--sticky-color-text); 
+.callout[data-callout~=sticky] .callout-content a.external-link {
+        color: var(--sticky-color-text);
+}
+.callout[data-callout~=sticky] mark {
+        opacity: 1;
 }
 
-.callout[data-callout~=sticky]:is([data-callout-metadata~=green]) { background-color: var(--sticky-color-green) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=red]) { background-color: var(--sticky-color-red) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=yellow]) { background-color: var(--sticky-color-yellow) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=blue]) { background-color: var(--sticky-color-blue) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=purple]) { background-color: var(--sticky-color-purple) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=aqua]) { background-color: var(--sticky-color-aqua) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=orange]) { background-color: var(--sticky-color-orange) !important; }
 
-.callout[data-callout~=sticky]:is([data-callout-metadata~=green]) mark { background-color: var(--sticky-color-green) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=red]) mark { background-color: var(--sticky-color-red) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=yellow]) mark { background-color: var(--sticky-color-yellow) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=blue]) mark { background-color: var(--sticky-color-blue) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=purple]) mark { background-color: var(--sticky-color-purple) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=aqua]) mark { background-color: var(--sticky-color-aqua) !important; }
-.callout[data-callout~=sticky]:is([data-callout-metadata~=orange]) mark { background-color: var(--sticky-color-orange) !important; }
-.callout[data-callout~=sticky] .callout-content mark { opacity: 1;}
 
 .callout[data-callout~=sticky]:is([data-callout-metadata~=title]) .callout-content:first-line {
-  font-weight: bold;
+        font-weight: bold;
+}
+
+
+
+
+/* width */
+.callout[data-callout~=sticky] {
+    width: var(--sticky-width);
+}
+.callout[data-callout~=sticky][data-callout-metadata~="s-35"] { width: 35%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-40"] { width: 40%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-45"] { width: 45%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-50"] { width: 50%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-55"] { width: 55%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-60"] { width: 60%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-65"] { width: 65%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-70"] { width: 70%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-75"] { width: 75%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-80"] { width: 80%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-85"] { width: 85%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-90"] { width: 90%; }
+.callout[data-callout~=sticky][data-callout-metadata~="s-95"] { width: 95%; }
+
+
+
+
+/* positioning and floating (technicallly the normal positioning is also called floating but only in code so..) */
+.callout.callout.callout[data-callout~=sticky]:is([data-callout-metadata~="left"]):not([data-callout-metadata~="float"]) {
+        float: left;
+        margin: unset;
+        margin-right: 8px;
 } 
-
-.sticky-zoom .callout[data-callout~=sticky]:hover, .callout[data-callout~=sticky]:focus{
-  box-shadow:10px 10px 7px rgba(40,40,40,.7);
-  transform: scale(1.25);
-  position:relative;
-  z-index:5;
-  opacity: 1;
-  transition: transform 0.5s ease 0s;
-  display: block;
+.callout.callout.callout[data-callout~=sticky]:is([data-callout-metadata~=nofloat]) {
+        float: unset !important;
+        margin-bottom: 20px !important;
+}  
+.callout.callout.callout[data-callout~=sticky]:is([data-callout-metadata~="right"]):not([data-callout-metadata~="float"]) {
+        float: right;
+        margin: unset;
+        margin-left: 8px;
+}
+.callout.callout.callout[data-callout~=sticky]:is([data-callout-metadata~="center"]):not([data-callout-metadata~="float"]) {
+        display: block;
+        margin: auto;
+        float: unset;
 }
 
-/* ===================================================
-   ASIDES
-   =================================================== */
 
-
-:is(.markdown-source-view .cm-callout, div:not([class])):has(> .callout[data-callout-metadata*="aside"]) {
-  position: relative;
-  overflow: visible;
+:is(.markdown-source-view .cm-callout, div:not([class])):has(> .callout[data-callout-metadata*="float"]) {
+        position: relative;
+        overflow: visible;
+}
+.callout[data-callout-metadata*="float"] {
+        position: absolute;
+}
+.callout[data-callout-metadata~="float"][data-callout-metadata~="left"],
+.callout[data-callout-metadata~="float"]:not([data-callout-metadata~="right"]) {
+        left: calc(-1 * (var(--sticky-width) + var(--sticky-offset)));
+        right: calc(100% + var(--sticky-offset));
+}
+.callout[data-callout-metadata~="float"][data-callout-metadata~="right"] {
+        left: calc(-1 * (var(--sticky-width) + var(--sticky-offset)));
+        right: calc(100% + var(--sticky-offset));
 }
 
-.callout[data-callout-metadata*="aside"] {
-  position: absolute;
+
+/* better markdown display */
+.markdown-source-view .callout[data-callout~=sticky] {
+        float: unset !important;
+        margin: auto !important;
+        position: relative;
+        max-width: calc(100% - var(--sticky-offset));
+        overflow: auto;
+        padding: 10px !important; 
+        background-color: var(--sticky-color-yellow) !important; 
+        display: block !important; 
+        opacity: 0.5 !important; 
 }
 
-.callout[data-callout-metadata~="aside"][data-callout-metadata~="left"],
-.callout[data-callout-metadata~="aside"]:not([data-callout-metadata~="right"]) {
-  left: calc(-1 * (var(--sticky-width) + var(--sticky-offset)));
-  right: calc(100% + var(--sticky-offset));
+.markdown-source-view .callout[data-callout~=sticky]:is([data-callout-metadata~="left"]):not([data-callout-metadata~="float"]):not([data-callout-metadata~="nofloat"]) {
+        float: left !important;
+        margin-right: 8px !important;
+}
+    
+.markdown-source-view .callout[data-callout~=sticky]:is([data-callout-metadata~="right"]):not([data-callout-metadata~="float"]):not([data-callout-metadata~="nofloat"]) {
+        float: right !important;
+        margin-left: 8px !important;
+}   
+.markdown-source-view .callout[data-callout~=sticky]:is([data-callout-metadata~="center"]):not([data-callout-metadata~="float"]) {
+        margin: auto !important;
+        float: unset !important;
 }
 
-.callout[data-callout-metadata~="aside"][data-callout-metadata~="right"] {
-  left: calc(var(--file-line-width) + var(--sticky-offset));
-  right: calc(-1 * var(--sticky-width));
-}
 
-/* @settings
-name: Sticky Notes
-id: sticky-notes
-settings:
-  -
-    id: info-text-sticky-notes
-    type: info-text
-    title: Sticky Notes by *Daniel Hansen*
-    description: Derived from *ITS Callout snippet*
-    markdown: true
-  -
-    id: sticky-color-default
-    title: Default
-    description: Default color for Sticky Notes. Used when not color is specified in markdown.
-    type: variable-color
-    format: rgb
-    opacity: true
-    default: '#FABD2FCC'
-  -
-    id: sticky-color-yellow
-    title: Yellow
-    description: Yellow sticky notes
-    type: variable-color
-    format: rgb
-    opacity: true
-    default: '#FABD2FCC'
-  -
-    id: sticky-color-green
-    title: Green
-    description: Green sticky notes
-    type: variable-color
-    format: rgb
-    opacity: true
-    default: '#b8bb26cc'
-  -
-    id: sticky-color-red
-    title: Red
-    description: Red sticky notes
-    type: variable-color
-    format: rgb
-    opacity: true
-    default: '#fb4934cc'
-  -
-    id: sticky-color-purple
-    title: Purple
-    description: Purple sticky notes
-    type: variable-color
-    format: rgb
-    opacity: true
-    default: '#d3869bcc'
-  -
-    id: sticky-color-aqua
-    title: Aqua
-    description: Aqua sticky notes
-    type: variable-color
-    format: rgb
-    opacity: true
-    default: '#8ec07ccc'
-  -
-    id: sticky-color-orange
-    title: Orange
-    description: Orange sticky notes
-    type: variable-color
-    format: rgb
-    opacity: true
-    default: '#fe8019cc'
-  -
-    id: sticky-color-text
-    title: Text color
-    description: Text Color
-    type: variable-color
-    format: rgb
-    opacity: false
-    default: '#333333'
-  -
-    id: sticky-font
-    title: Sticky Notes font
-    description: Font used for sticky notes.
-    type: variable-select
-    default: Roboto
-    options:
-      -
-        label: IBM Plex Sans
-        value: IBM Plex Sans
-      -
-        label: IBM Plex Mono
-        value: IBM Plex Mono
-      -
-        label: Roboto
-        value: Roboto
-      -
-        label: Chilanka
-        value: Chilanka
-      -
-        label: Kalam
-        value: Kalam
-      -
-        label: Architects Daughter
-        value: Architects Daughter
-      -
-        label: Edu SA Beginner
-        value: Edu SA Beginner
-      -
-        label: Playpen Sans
-        value: Playpen Sans
-      -
-        label: Shantell Sans
-        value: Shantell Sans
-  -
-    id: sticky-font-size
-    title: Sticky Notes font size
-    description: Size of the Sticky Notes text
-    type: variable-text
-    default: 1.2em
-  -
-    id: sticky-offset
-    title: Sticky offset (Aside)
-    description: When using Aside, the offset between the sticky and the text
-    type: variable-number-slider
-    default: 12
-    min: 0
-    max: 50
-    step: 1
-    format: px
-  -
-    id: sticky-zoom
-    title: Zoom on hover
-    description: Zooms sticky notes on mouse hover (experimental)
-    type: class-toggle
-*/
+
+/* colors */
+.callout[data-callout~=sticky][data-callout-metadata~="green"] { background-color: var(--sticky-color-green) !important; }
+.callout[data-callout~=sticky][data-callout-metadata~="red"] { background-color: var(--sticky-color-red) !important; }
+.callout[data-callout~=sticky][data-callout-metadata~="yellow"] { background-color: var(--sticky-color-yellow) !important; }
+.callout[data-callout~=sticky][data-callout-metadata~="blue"] { background-color: var(--sticky-color-blue) !important; }
+.callout[data-callout~=sticky][data-callout-metadata~="purple"] { background-color: var(--sticky-color-purple) !important; }
+.callout[data-callout~=sticky][data-callout-metadata~="aqua"] { background-color: var(--sticky-color-aqua) !important; }
+.callout[data-callout~=sticky][data-callout-metadata~="orange"] { background-color: var(--sticky-color-orange) !important; }
+
+.markdown-source-view .callout[data-callout~=sticky][data-callout-metadata~="green"][data-callout-metadata*="float"] { background-color: var(--sticky-color-green-transparent) !important; }
+.markdown-source-view .callout[data-callout~=sticky][data-callout-metadata~="red"][data-callout-metadata*="float"] { background-color: var(--sticky-color-red-transparent) !important; }
+.markdown-source-view .callout[data-callout~=sticky][data-callout-metadata~="yellow"][data-callout-metadata*="float"] { background-color: var(--sticky-color-yellow-transparent) !important; }
+.markdown-source-view .callout[data-callout~=sticky][data-callout-metadata~="blue"][data-callout-metadata*="float"] { background-color: var(--sticky-color-blue-transparent) !important; }
+.markdown-source-view .callout[data-callout~=sticky][data-callout-metadata~="purple"][data-callout-metadata*="float"] { background-color: var(--sticky-color-purple-transparent) !important; }
+.markdown-source-view .callout[data-callout~=sticky][data-callout-metadata~="aqua"][data-callout-metadata*="float"] { background-color: var(--sticky-color-aqua-transparent) !important; }
+.markdown-source-view .callout[data-callout~=sticky][data-callout-metadata~="orange"][data-callout-metadata*="float"] { background-color: var(--sticky-color-orange-transparent) !important; }


### PR DESCRIPTION
new and expanded features
- Floating cue section / aside
	- `| float` metadata/parameter to make a sticky note float to the left side of your note. ex. `> [!sticky | blue float s-40]`
	- this placement mirrors the cue section of the *Cornell note-taking system*.
	- why not right side? we read from left to right, so the cue stickies will gain more attention.
	- In editing mode, floating stickies will return to the normal margins but with a more transparent look, indicating that it is a floating/cue sticky. Note: don't space floating sticky notes closely in line numbers or else they would overlap. Why would you even need multiple cue stickies that close? you should have floating notes at s-30, you can make it larger, but it will overlap to the main notes section, if you still want it to be that large but not overlap, you can use `<br>` tags.
- Zoom on hover - self-explanatory
- Collapsible stickies 
	- add a `+` or `-` sign after `[!sticky|metadata]` to make it collapsible with the default state of open and close correspondently. ex. `> [!sticky | yellow]-`
	- clicking on the arrow`>` or header on top of the sticky note will expand/collapse it.
- more sticky widths, up to 95%
- standardized all markdown colors in sticky note.
- slightly changed color system, should be natural for both dark and light mode
- removed default titles and callout icons.

- *Optimized Sub-optimal*